### PR TITLE
feat: add development container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Osuny development server",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/go:1": {},
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "extended": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "forwardPorts": ["localhost:1313"],
+  "portsAttributes": {
+    "1313": {
+      "label": "Osuny development server"
+    }
+  },
+  "containerEnv": {
+    "HUGO_BASEURL": "http://localhost:1313/"
+  },
+  "postCreateCommand": {
+    "osuny": "yarn install"
+  },
+  "postStartCommand": "yarn develop"
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ Two workflows are used for this repository:
 - `deploy-main-deuxfleurs-garage.yml` to deploy the `main` branch in the osunyorg/idn-website repository to DeuxFleurs' Garage service, published at [degrowth.net/](https://degrowth.net)
 - `preview-next-github-pages.yml` to preview the `next` branch in the degrowth/idn-website fork with GitHub pages, published at [next.degrowth.net/](https://next.degrowth.net)
 
+## Development Container
+
+This repository contains a `.devcontainer.json` configuration file, which provides configuration for a [Development Container](https://containers.dev/).
+
+It can be sued with GitHub Codespaces: [Introduction to dev containers - GitHub Docs](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers).
+
+You can also [use the development container extension for Microsoft Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers).
+
+<details><summary>Advanced usage with the official CLI.</summary>
+
+The CLI currently has no support for `forwardPorts`[¹](https://github.com/devcontainers/cli/issues/22). We need to patch the container to use the depreciated `appPort` setting instead.
+
+Install the CLI:
+
+```sh
+yarn global add @devcontainers/cli
+```
+
+Patch the development container to use `appPort` instead of `forwardPorts`:
+
+```sh
+sed -e 's/forwardPorts/appPort/' -e 's/"localhost:1313"/"1313:1313"/' -i .devcontainer.json
+```
+
+Lify cycle of a development container:
+
+```sh
+devcontainer build --workspace-folder ./
+devcontainer up --workspace-folder ./
+```
+
+You can now open the website generated from the development server at http://localhost:1313/.
+
+</details>
+
 ## Authors
 
 - Taylor A. Ahlstrom

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "osuny": "./themes/osuny"
   },
   "scripts": {
-    "osuny": "npx osuny-hugo-theme"
+    "osuny": "npx osuny-hugo-theme",
+    "build": "hugo --minify; yarn pagefind",
+    "develop": "hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --bind 0.0.0.0"
   }
 }

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,0 +1,25 @@
+site: public
+exclude_selectors:
+  - .categories__taxonomy
+  - .categories__term
+  - .posts_categories__taxonomy
+  - .posts_categories__term
+  - .events_categories__taxonomy
+  - .events_categories__term
+  - .diplomas__taxonomy
+  - .block-diplomas
+  - .events__section
+  - .block-agenda
+  - .organizations__section
+  - .block-organizations
+  - .block-pages
+  - .persons__section
+  - .block-persons
+  - .administrators__term
+  - .authors__term
+  - .researchers__term
+  - .teachers__term
+  - .posts__section
+  - .block-posts
+  - .post-sidebar
+  - .block-programs


### PR DESCRIPTION
This:

- adds pagefind.yml to automate pagefind runs with less command line parameters
- adds .devcontainer.json

It can be used with

- Microsoft GitHub Codespaces
- Microsoft Visual Studio Code
- the Development Containers CLI

This also:

* updates package.json to contain dedicated build and develop scripts supersedes osuny.js
* updates README.md to mention the development container

closes #13