### PR TITLE
fix: devcontainer compatibility with Codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,7 +9,7 @@
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },
-  "forwardPorts": ["localhost:1313"],
+  "appPort": ["1313:1313"],
   "portsAttributes": {
     "1313": {
       "label": "Osuny development server"
@@ -18,8 +18,6 @@
   "containerEnv": {
     "HUGO_BASEURL": "http://localhost:1313/"
   },
-  "postCreateCommand": {
-    "osuny": "yarn install"
-  },
+  "postCreateCommand": "yarn run init",
   "postStartCommand": "yarn develop"
 }

--- a/.github/codespaces.app.url
+++ b/.github/codespaces.app.url
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+CODESPACE_PORT="$(jq -r '.appPort[] | capture("(?<port>[0-9]+)") | .port' .devcontainer.json)"
+echo "https://${CODESPACE_NAME}-${CODESPACE_PORT}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}/"

--- a/README.md
+++ b/README.md
@@ -35,31 +35,31 @@ yarn osuny build
 
 Two workflows are used for this repository:
 
-- `deploy-main-deuxfleurs-garage.yml` to deploy the `main` branch in the osunyorg/idn-website repository to DeuxFleurs' Garage service, published at [degrowth.net/](https://degrowth.net)
-- `preview-next-github-pages.yml` to preview the `next` branch in the degrowth/idn-website fork with GitHub pages, published at [next.degrowth.net/](https://next.degrowth.net)
+- `deuxfleurs.yml` to deploy the `main` branch in the [osunyorg/idn-website](https://github.com/osunyorg/idn-website) repository to DeuxFleurs' Garage service, published at [degrowth.net/](https://degrowth.net)
+- `preview-next-github-pages.yml` to preview the `next` branch in the [degrowth/idn-website](https://github.com/degrowth/idn-website) fork with GitHub pages, published at [next.degrowth.net/](https://next.degrowth.net)
 
 ## Development Container
 
 This repository contains a `.devcontainer.json` configuration file, which provides configuration for a [Development Container](https://containers.dev/).
 
-It can be sued with GitHub Codespaces: [Introduction to dev containers - GitHub Docs](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers).
+It can be used with GitHub Codespaces: [Introduction to dev containers - GitHub Docs](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers).
 
-You can also [use the development container extension for Microsoft Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers).
+After GitHub Codespaces has started the development container, you can start an integrated development server with:
+
+```sh
+$ yarn codespaces
+```
+
+You can also [use the development container extension for Microsoft Visual Studio Code](https://code.visualstudio.com/docs/devcontainers/containers). Install the extension: [Dev Containers - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Once installed, it will prompt you, when a development container is detected in a repository. Do what the prompt suggests and your Osuny build environment is made available from within the container.
 
 <details><summary>Advanced usage with the official CLI.</summary>
 
-The CLI currently has no support for `forwardPorts`[¹](https://github.com/devcontainers/cli/issues/22). We need to patch the container to use the depreciated `appPort` setting instead.
+The CLI currently has no support for `forwardPorts`[¹](https://github.com/devcontainers/cli/issues/22), why we keep compatibility with using the `appPort` setting.
 
 Install the CLI:
 
 ```sh
 yarn global add @devcontainers/cli
-```
-
-Patch the development container to use `appPort` instead of `forwardPorts`:
-
-```sh
-sed -e 's/forwardPorts/appPort/' -e 's/"localhost:1313"/"1313:1313"/' -i .devcontainer.json
 ```
 
 Lify cycle of a development container:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "init": "git submodule update --init --recursive; yarn install",
     "build": "hugo --minify; yarn pagefind",
     "codespaces": "hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --appendPort=false --bind 0.0.0.0 --baseURL $(.github/codespaces.app.url)",
-    "develop": "sh -c 'if (env | grep CODESPACES >/dev/null 2>&1); then true; else hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --bind 0.0.0.0; fi'"
+    "develop": "sh -c 'if (env | grep ^CODESPACES=true >/dev/null 2>&1); then true; else hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --bind 0.0.0.0; fi'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "osuny": "npx osuny-hugo-theme",
+    "init": "git submodule update --init --recursive; yarn install",
     "build": "hugo --minify; yarn pagefind",
-    "develop": "hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --bind 0.0.0.0"
+    "codespaces": "hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --appendPort=false --bind 0.0.0.0 --baseURL $(.github/codespaces.app.url)",
+    "develop": "sh -c 'if (env | grep CODESPACES >/dev/null 2>&1); then true; else hugo; yarn pagefind --output-subdir ../static/pagefind; hugo server --bind 0.0.0.0; fi'"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,9 +146,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001629:
-  version "1.0.30001632"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz#964207b7cba5851701afb4c8afaf1448db3884b6"
-  integrity sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==
+  version "1.0.30001638"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz#598e1f0c2ac36f37ebc3f5b8887a32ca558e5d56"
+  integrity sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==
 
 chokidar@^3.3.0:
   version "3.6.0"
@@ -452,9 +452,9 @@ domutils@^3.0.1:
     domhandler "^5.0.3"
 
 electron-to-chromium@^1.4.796:
-  version "1.4.798"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.798.tgz#6a3fcab2edc1e66e3883466f6b4b8944323c0164"
-  integrity sha512-by9J2CiM9KPGj9qfp5U4FcPSbXJG7FNzqnYaY4WLzX+v2PHieVGmnsA4dxfpGE3QEC7JofpPZmn7Vn1B9NR2+Q==
+  version "1.4.814"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.814.tgz#176535a0b899c9c473464502ab77576aa8bb1cbe"
+  integrity sha512-GVulpHjFu1Y9ZvikvbArHmAhZXtm3wHlpjTMcXNGKl4IQ4jMQjlnz8yMQYYqdLHKi/jEL2+CBC2akWVCoIGUdw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -588,7 +588,7 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-hasown@^2.0.0:
+hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -631,11 +631,11 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-core-module@^2.13.0:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
-  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.14.0.tgz#43b8ef9f46a6a08888db67b1ffd4ec9e3dfd59d1"
+  integrity sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==
   dependencies:
-    hasown "^2.0.0"
+    hasown "^2.0.2"
 
 is-extglob@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
* adds .github/codespaces.app.url as a mixin to generate the automatically generated URL for the website
* adds init and codespaces commands to package.json

- modifies the develop command in package.json to only run outside of codespaces
- modifies the development container to revert to appPort for compatibility, and to run the new init script
- modifies the README to explain Codespaces steps
- modifies yarn.lock

closes #15 