### PR TITLE
fix: expose link checker results publicly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/preview-next-github-pages.yml
+++ b/.github/workflows/preview-next-github-pages.yml
@@ -7,20 +7,21 @@ on:
     branches:
       - next
     paths:
-      - 'package.json'
-      - 'yarn.lock'
-      - '.gitmodules'
+      - "package.json"
+      - "pagefind.yml"
+      - "yarn.lock"
+      - ".gitmodules"
 
-      - '.github/workflows/preview-next-github-pages.yml'
-      - '.github/lychee.**'
+      - ".github/workflows/preview-next-github-pages.yml"
+      - ".github/lychee.**"
 
-      - 'assets'
-      - 'config'
-      - 'content'
-      - 'data'
-      - 'i18n'
-      - 'static'
-      - 'themes'
+      - "assets"
+      - "config"
+      - "content"
+      - "data"
+      - "i18n"
+      - "static"
+      - "themes"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -34,7 +35,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: 'pages'
+  group: "pages"
   cancel-in-progress: false
 
 # Default to bash
@@ -43,7 +44,7 @@ defaults:
     shell: bash
 
 env:
-  BASEURL: https://next.degrowth.net
+  BASE_URL: https://next.degrowth.net
 
 jobs:
   build:
@@ -82,7 +83,7 @@ jobs:
 
       - name: Build the site
         env:
-          HUGO_BASEURL: ${{ env.BASEURL }}
+          HUGO_BASEURL: ${{ env.BASE_URL }}
         run: yarn osuny build
 
       - name: Upload artifact
@@ -120,7 +121,7 @@ jobs:
           CONFIG: .github/lychee.external.toml
           INPUT: public
         with:
-          args: -c ${{ env.CONFIG }} --base ${{ env.BASEURL }} --no-progress --include-fragments ${{ env.INPUT }}
+          args: -c ${{ env.CONFIG }} --base ${{ env.BASE_URL }} --no-progress --include-fragments ${{ env.INPUT }}
           format: markdown
           output: .lychee.report.external.md
           jobSummary: true
@@ -130,7 +131,6 @@ jobs:
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}
-
 
   # Deploy to GitHub Pages
   deploy:
@@ -180,7 +180,7 @@ jobs:
           CONFIG: .github/lychee.internal.toml
           INPUT: public
         with:
-          args: -c ${{ env.CONFIG }} --base ${{ env.BASEURL }} --no-progress --include-fragments ${{ env.INPUT }}
+          args: -c ${{ env.CONFIG }} --base ${{ env.BASE_URL }} --no-progress --include-fragments ${{ env.INPUT }}
           format: markdown
           output: .lychee.report.internal.md
           jobSummary: true

--- a/.github/workflows/preview-next-github-pages.yml
+++ b/.github/workflows/preview-next-github-pages.yml
@@ -31,6 +31,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -50,6 +51,8 @@ jobs:
   build:
     name: Build Hugo page
     runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.finder.outputs.pr }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -92,6 +95,9 @@ jobs:
           name: preview-build
           path: ./public
 
+      - uses: jwalton/gh-find-current-pr@v1
+        id: finder
+
   checkExternalLinks:
     name: Check external links
     runs-on: ubuntu-latest
@@ -125,6 +131,15 @@ jobs:
           format: markdown
           output: .lychee.report.external.md
           jobSummary: true
+      - name: Comment link checking results to merged PR
+        if: needs.build.outputs.pr_number
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: external
+          number: ${{ needs.build.outputs.pr_number }}
+          path: .lychee.report.external.md
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
       - name: Save lychee cache
         uses: actions/cache/save@v4
         if: always()
@@ -184,6 +199,15 @@ jobs:
           format: markdown
           output: .lychee.report.internal.md
           jobSummary: true
+      - name: Comment link checking results to merged PR
+        if: needs.build.outputs.pr_number
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: internal
+          number: ${{ needs.build.outputs.pr_number }}
+          path: .lychee.report.internal.md
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
       - name: Save lychee cache
         uses: actions/cache/save@v4
         if: always()

--- a/.github/workflows/preview-next-github-pages.yml
+++ b/.github/workflows/preview-next-github-pages.yml
@@ -15,13 +15,13 @@ on:
       - ".github/workflows/preview-next-github-pages.yml"
       - ".github/lychee.**"
 
-      - "assets"
-      - "config"
-      - "content"
-      - "data"
-      - "i18n"
-      - "static"
-      - "themes"
+      - "assets/**"
+      - "config/**"
+      - "content/**"
+      - "data/**"
+      - "i18n/**"
+      - "static/**"
+      - "themes/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The results from link check runs are now published as comments to the PR that initiated the run.

Also adds a dependabot to keep actions fresh for security reasons.

addresses #17 