### PR TITLE
fix(ci): link checker conditions

### DIFF
--- a/.github/workflows/preview-next-github-pages.yml
+++ b/.github/workflows/preview-next-github-pages.yml
@@ -95,8 +95,11 @@ jobs:
           name: preview-build
           path: ./public
 
-      - uses: jwalton/gh-find-current-pr@v1
+      - name: Find merged Pull Request
+        uses: jwalton/gh-find-current-pr@v1
         id: finder
+        with:
+          state: closed
 
   checkExternalLinks:
     name: Check external links
@@ -132,7 +135,7 @@ jobs:
           output: .lychee.report.external.md
           jobSummary: true
       - name: Comment link checking results to merged PR
-        if: needs.build.outputs.pr_number
+        if: ${{ needs.build.outputs.pr_number }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: external
@@ -200,7 +203,7 @@ jobs:
           output: .lychee.report.internal.md
           jobSummary: true
       - name: Comment link checking results to merged PR
-        if: needs.build.outputs.pr_number
+        if: ${{ needs.build.outputs.pr_number }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: internal


### PR DESCRIPTION
We need to explicitly want to find closed PRs.

We also need to evaluate the `if:` expression, because no operator is present in the line.

addresses #17 