### PR TITLE
fix(lychee): do not check mailboxes' deliverability

### DIFF
--- a/.github/lychee.external.toml
+++ b/.github/lychee.external.toml
@@ -130,4 +130,4 @@ exclude_link_local = false
 exclude_loopback = false
 
 # Check mail addresses
-include_mail = true
+include_mail = false

--- a/.github/lychee.internal.toml
+++ b/.github/lychee.internal.toml
@@ -95,9 +95,7 @@ include_verbatim = false
 glob_ignore_case = false
 
 # Exclude URLs and mail addresses from checking (supports regex).
-exclude = [
-    '.*'
-]
+exclude = ['.*']
 
 # Exclude these filesystem paths from getting checked.
 # exclude_path = [
@@ -112,10 +110,7 @@ exclude = [
 # ]
 
 # URLs to check (supports regex). Has preference over all excludes.
-include = [
-    'https://next.degrowth.net/.*',
-    'https://degrowth.net/.*',
-]
+include = ['https://next.degrowth.net/.*', 'https://degrowth.net/.*']
 
 # Exclude all private IPs from checking.
 # Equivalent to setting `exclude_private`, `exclude_link_local`, and

--- a/.github/lychee.internal.toml
+++ b/.github/lychee.internal.toml
@@ -127,4 +127,4 @@ exclude_link_local = false
 exclude_loopback = false
 
 # Check mail addresses
-include_mail = true
+include_mail = false


### PR DESCRIPTION
addresses lycheeverse/lychee#1462 where Mastodon `https://` links in HTML are tried for the email mailboxes in the anchor.